### PR TITLE
Relax download_url type constraints - rely on Archive support for urls

### DIFF
--- a/manifests/alertmanager.pp
+++ b/manifests/alertmanager.pp
@@ -132,7 +132,7 @@ class prometheus::alertmanager (
   Stdlib::Absolutepath $config_dir,
   Stdlib::Absolutepath $config_file,
   String $download_extension,
-  Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl] $download_url_base,
+  Optional[Stdlib::Filesource] $download_url_base,
   Array $extra_groups,
   Hash $global,
   String $group,

--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -55,7 +55,7 @@
 #
 define prometheus::daemon (
   String $version,
-  Variant[Stdlib::HTTPSUrl, Stdlib::HTTPUrl] $real_download_url,
+  Stdlib::Filesource $real_download_url,
   $notify_service,
   String $user,
   String $group,

--- a/manifests/haproxy_exporter.pp
+++ b/manifests/haproxy_exporter.pp
@@ -81,7 +81,7 @@ class prometheus::haproxy_exporter(
   String $package_name,
   String $user,
   String $version,
-  Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl] $download_url_base,
+  Optional[Stdlib::Filesource] $download_url_base,
   Boolean $purge_config_dir      = true,
   Boolean $restart_on_change     = true,
   Boolean $service_enable        = true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -145,7 +145,7 @@ class prometheus (
   Stdlib::Absolutepath $shared_dir,
   String $version,
   String $install_method,
-  Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl] $download_url_base,
+  Optional[Stdlib::Filesource] $download_url_base,
   String $download_extension,
   String $package_name,
   String $package_ensure,

--- a/manifests/mysqld_exporter.pp
+++ b/manifests/mysqld_exporter.pp
@@ -97,7 +97,7 @@ class prometheus::mysqld_exporter (
   Stdlib::Port $cnf_port,
   String $cnf_user,
   String $download_extension,
-  Variant[Stdlib::HTTPSUrl, Stdlib::HTTPUrl] $download_url_base,
+  Optional[Stdlib::Filesource] $download_url_base,
   Array $extra_groups,
   String $group,
   String $package_ensure,

--- a/manifests/process_exporter.pp
+++ b/manifests/process_exporter.pp
@@ -92,7 +92,7 @@ class prometheus::process_exporter(
   String $os                                                         = $prometheus::os,
   String $extra_options                                              = '',
   String $config_mode                                                = $prometheus::config_mode,
-  Optional[Variant[Stdlib::HTTPSUrl, Stdlib::HTTPUrl]] $download_url = undef,
+  Optional[Stdlib::Filesource] $download_url = undef,
   String $arch                                                       = $prometheus::real_arch,
   Stdlib::Absolutepath $bin_dir                                      = $prometheus::bin_dir,
 ) inherits prometheus {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -9,7 +9,7 @@ class prometheus::server (
   Stdlib::Absolutepath $shared_dir                                              = $prometheus::shared_dir,
   String $version                                                               = $prometheus::version,
   String $install_method                                                        = $prometheus::install_method,
-  Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl] $download_url_base                 = $prometheus::download_url_base,
+  Stdlib::Filesource $download_url_base                                         = $prometheus::download_url_base,
   String $download_extension                                                    = $prometheus::download_extension,
   String $package_name                                                          = $prometheus::package_name,
   String $package_ensure                                                        = $prometheus::package_ensure,

--- a/manifests/statsd_exporter.pp
+++ b/manifests/statsd_exporter.pp
@@ -82,7 +82,7 @@
 
 class prometheus::statsd_exporter (
   String $download_extension,
-  Variant[Stdlib::HTTPSUrl, Stdlib::HTTPUrl] $download_url_base,
+  Optional[Stdlib::Filesource] $download_url_base,
   Array $extra_groups,
   String $group,
   Stdlib::Absolutepath $mapping_config_path,

--- a/manifests/varnish_exporter.pp
+++ b/manifests/varnish_exporter.pp
@@ -79,7 +79,7 @@ class prometheus::varnish_exporter(
   String $package_name,
   String $user,
   String $version,
-  Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl] $download_url_base,
+  Optional[Stdlib::Filesource] $download_url_base,
   Boolean $purge_config_dir      = true,
   Boolean $restart_on_change     = true,
   Boolean $service_enable        = true,

--- a/spec/defines/daemon_spec.rb
+++ b/spec/defines/daemon_spec.rb
@@ -18,7 +18,7 @@ describe 'prometheus::daemon' do
       [
         {
           version:           '1.2.3',
-          real_download_url: 'https://github.com/prometheus/smurf_exporter/releases/v1.2.3/smurf_exporter-1.2.3.any.tar.gz',
+          real_download_url: 'file:///opt/assets/smurf_exporter-1.2.3.any.tar.gz',
           notify_service:    'Service[smurf_exporter]',
           user:              'smurf_user',
           group:             'smurf_group',


### PR DESCRIPTION
Instead of insisting that download urls are http(s)? only to pass these thru to the `archive` module - accept whatever archive accepts. Allows for delivering the binaries from file:/// or s3:/// etc.
