### PR TITLE
Added init_style redhat for compatibility with Amazon Linux: as per h…

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -71,7 +71,7 @@ class prometheus::config {
           content => template('prometheus/prometheus.systemd.erb'),
         }
       }
-      'sysv' : {
+      'sysv', 'redhat' : {
         file { '/etc/init.d/prometheus':
           mode    => '0555',
           owner   => 'root',


### PR DESCRIPTION
prometheus won't install as it doesn't recognise "redhat" as an init_style
